### PR TITLE
Don't delegate queue_name to parent_manager

### DIFF
--- a/app/models/manageiq/providers/nsxt/network_manager.rb
+++ b/app/models/manageiq/providers/nsxt/network_manager.rb
@@ -29,6 +29,10 @@ class ManageIQ::Providers::Nsxt::NetworkManager < ManageIQ::Providers::NetworkMa
     self[:name]
   end
 
+  def queue_name_for_ems_refresh
+    queue_name
+  end
+
   def cloud_tenants
     ::CloudTenant.where(:ems_id => id)
   end


### PR DESCRIPTION
Needed for: https://github.com/ManageIQ/manageiq/pull/20345