### PR TITLE
Fix provider availability logic

### DIFF
--- a/app/javascript/utils/providers.api.js
+++ b/app/javascript/utils/providers.api.js
@@ -12,10 +12,10 @@ export class ProvidersApi {
     const providers = await ProvidersApi.list(
       {filter: 'filter[]=type=ManageIQ::Providers::Nsxt::NetworkManager'}
     );
-    if (1 < providers.length) {
+    if (providers.length < 1) {
       throw 'The NSX-T provider is missing';
     }
-    if (providers.length < 1) {
+    if (providers.length > 1) {
       throw 'More than one NSX-T provider found, could not determine the correct provider';
     }
     return providers[0];


### PR DESCRIPTION
I think if the `length` of `provider` array is less than `1`, then the NSX-T provider is missing and if the `length` is more than `1`, then there's more than one provider available. Thus fixing the logic accordingly.