### PR TITLE
Created DDF schema and validation method for provider creation

### DIFF
--- a/app/models/manageiq/providers/nsxt/manager_mixin.rb
+++ b/app/models/manageiq/providers/nsxt/manager_mixin.rb
@@ -4,8 +4,8 @@ module ManageIQ::Providers::Nsxt::ManagerMixin
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def raw_connect(base_url, username, password)
-      ManageIQ::Providers::Nsxt::NsxtClient.new(base_url, username, password)
+    def raw_connect(base_url, username, password, verify_ssl = false)
+      ManageIQ::Providers::Nsxt::NsxtClient.new(base_url, username, password, verify_ssl)
     end
 
     def translate_exception(err)
@@ -29,7 +29,7 @@ module ManageIQ::Providers::Nsxt::ManagerMixin
   end
 
   def base_url(protocol, server, port)
-    scheme = %w[ssl ssl-with-validation].include?(protocol) ? "https" : "http"
+    scheme = protocol == 'non-ssl' ? "http" : "https"
     URI::Generic.build(:scheme => scheme, :host => server, :port => port).to_s
   end
 

--- a/app/models/manageiq/providers/nsxt/manager_mixin.rb
+++ b/app/models/manageiq/providers/nsxt/manager_mixin.rb
@@ -22,15 +22,110 @@ module ManageIQ::Providers::Nsxt::ManagerMixin
         MiqException::MiqEVMLoginError.new "Unexpected response returned from system: #{err.message}"
       end
     end
+
+    def params_for_create
+      @params_for_create ||= {
+        :fields => [
+          {
+            :component => 'switch',
+            :id        => 'tenant_mapping_enabled',
+            :name      => 'tenant_mapping_enabled',
+            :label     => _('Tenant Mapping Enabled'),
+          },
+          {
+            :component => 'sub-form',
+            :id        => 'endpoints-subform',
+            :name      => 'endpoints-subform',
+            :title     => _("Endpoints"),
+            :fields    => [
+              {
+                :component              => 'validate-provider-credentials',
+                :id                     => 'endpoints.default.valid',
+                :name                   => 'endpoints.default.valid',
+                :skipSubmit             => true,
+                :validationDependencies => %w[type zone_id],
+                :fields                 => [
+                  {
+                    :component  => "select",
+                    :id         => "endpoints.default.security_protocol",
+                    :name       => "endpoints.default.security_protocol",
+                    :label      => _("Security Protocol"),
+                    :isRequired => true,
+                    :validate   => [{:type => "required"}],
+                    :options    => [
+                      {
+                        :label => _("SSL without validation"),
+                        :value => "ssl-no-validation"
+                      },
+                      {
+                        :label => _("SSL"),
+                        :value => "ssl-with-validation"
+                      },
+                      {
+                        :label => _("Non-SSL"),
+                        :value => "non-ssl"
+                      }
+                    ]
+                  },
+                  {
+                    :component  => "text-field",
+                    :id         => "endpoints.default.hostname",
+                    :name       => "endpoints.default.hostname",
+                    :label      => _("Hostname (or IPv4 or IPv6 address)"),
+                    :isRequired => true,
+                    :validate   => [{:type => "required"}]
+                  },
+                  {
+                    :component    => "text-field",
+                    :id           => "endpoints.default.port",
+                    :name         => "endpoints.default.port",
+                    :label        => _("API Port"),
+                    :type         => "number",
+                    :isRequired   => true,
+                    :validate     => [{:type => "required"}],
+                    :initialValue => 443,
+                  },
+                  {
+                    :component  => "text-field",
+                    :id         => "authentications.default.userid",
+                    :name       => "authentications.default.userid",
+                    :label      => _("Username"),
+                    :isRequired => true,
+                    :validate   => [{:type => "required"}],
+                  },
+                  {
+                    :component  => "password-field",
+                    :id         => "authentications.default.password",
+                    :name       => "authentications.default.password",
+                    :label      => _("Password"),
+                    :type       => "password",
+                    :isRequired => true,
+                    :validate   => [{:type => "required"}],
+                  },
+                ],
+              },
+            ],
+          },
+        ]
+      }.freeze
+    end
+
+    def verify_credentials(args)
+      endpoint = args.dig("endpoints", 'default')
+      hostname, security_protocol, port = endpoint&.values_at('hostname', 'security_protocol', 'port')
+      authentication = args.dig("authentications", "default")
+      userid, password = authentication&.values_at('userid', 'password')
+      !!raw_connect(base_url(security_protocol, hostname, port), userid, password, security_protocol == 'ssl-with-validation')
+    end
+
+    def base_url(protocol, server, port)
+      scheme = protocol == 'non-ssl' ? "http" : "https"
+      URI::Generic.build(:scheme => scheme, :host => server, :port => port).to_s
+    end
   end
 
   def description
     "Vmware NSX-T"
-  end
-
-  def base_url(protocol, server, port)
-    scheme = protocol == 'non-ssl' ? "http" : "https"
-    URI::Generic.build(:scheme => scheme, :host => server, :port => port).to_s
   end
 
   def connect(options = {})
@@ -42,7 +137,7 @@ module ManageIQ::Providers::Nsxt::ManagerMixin
     username = options[:user] || authentication_userid(options[:auth_type])
     password = options[:pass] || authentication_password(options[:auth_type])
 
-    url = base_url(protocol, server, port)
+    url = self.class.base_url(protocol, server, port)
     self.class.raw_connect(url, username, password)
   end
 

--- a/app/models/manageiq/providers/nsxt/network_manager.rb
+++ b/app/models/manageiq/providers/nsxt/network_manager.rb
@@ -25,6 +25,10 @@ class ManageIQ::Providers::Nsxt::NetworkManager < ManageIQ::Providers::NetworkMa
     @description ||= "VMware NSX-T Network Manager".freeze
   end
 
+  def self.supported_for_create?
+    true
+  end
+
   def name
     self[:name]
   end

--- a/app/models/manageiq/providers/nsxt/nsxt_client.rb
+++ b/app/models/manageiq/providers/nsxt/nsxt_client.rb
@@ -3,16 +3,15 @@ require 'rubygems'
 require 'json'
 class ManageIQ::Providers::Nsxt::NsxtClient
   include Vmdb::Logging
-  def initialize(server, user, password)
+  def initialize(server, user, password, verify_ssl = false)
     @server = server
     @user = user
     @password = password
-    @client = Rest.new(server, user, password)
+    @client = Rest.new(server, user, password, verify_ssl)
     connected, data = @client.login
-    if connected
-      return
-    end
-    $nsxt_log.error('NSX-T Authentication failed')
+    return if connected
+
+    raise 'NSX-T Authentication failed'
   end
 
   def get_tier_1(id)

--- a/app/models/manageiq/providers/nsxt/nsxt_client/rest.rb
+++ b/app/models/manageiq/providers/nsxt/nsxt_client/rest.rb
@@ -1,15 +1,16 @@
 class ManageIQ::Providers::Nsxt::NsxtClient::Rest
   include Vmdb::Logging
-  def initialize(server, user, password)
+  def initialize(server, user, password, verify_ssl)
     @server = server
     @user = user
     @password = password
+    @verify_ssl = verify_ssl
   end
 
   def login
     @login_url = @server + "/api/v1/license"
     RestClient::Request.execute(:method => :get, :url => @login_url, :user => @user, :password => @password,
-    :headers => @headers, :verify_ssl => false) do |response|
+    :headers => @headers, :verify_ssl => @verify_ssl) do |response|
       case response.code
       when 200
         data = JSON.parse(response.body)
@@ -40,7 +41,7 @@ class ManageIQ::Providers::Nsxt::NsxtClient::Rest
     request(url, :method => :post, :data => data)
   end
 
-  def request(url, method: :get, data: nil, verify_ssl: false)
+  def request(url, method: :get, data: nil, verify_ssl: @verify_ssl)
     $nsxt_log.debug("NSX-T request with url #{url}")
     response = RestClient::Request.execute(
       :url        => url,


### PR DESCRIPTION
There was no DDF schema for provider creation, so I implemented one based on the screenshot provided [here](https://github.com/ManageIQ/manageiq-providers-nsxt/issues/14#issuecomment-687003729). The backend code was mentioning a protocol field, but there was no such thing in the form. As a fix I implemented an optional SSL certificate verification in the REST client and updated the form schema with the protocol selector component.

![Screenshot from 2020-09-08 20-29-22](https://user-images.githubusercontent.com/649130/92514344-0676bf00-f212-11ea-8173-f434572ea076.png)

Closes https://github.com/ManageIQ/manageiq-providers-nsxt/issues/14
Depends on https://github.com/ManageIQ/manageiq-ui-classic/pull/7279
