### PR TITLE
Make the default credentials required in the provider DDF

### DIFF
--- a/app/models/manageiq/providers/nsxt/manager_mixin.rb
+++ b/app/models/manageiq/providers/nsxt/manager_mixin.rb
@@ -43,6 +43,7 @@ module ManageIQ::Providers::Nsxt::ManagerMixin
                 :id                     => 'endpoints.default.valid',
                 :name                   => 'endpoints.default.valid',
                 :skipSubmit             => true,
+                :isRequired             => true,
                 :validationDependencies => %w[type zone_id],
                 :fields                 => [
                   {


### PR DESCRIPTION
The default behavior for the `async-credentials` component is [changing to be optional](https://github.com/ManageIQ/manageiq-ui-classic/pull/7347), so it has to be explicitly marked as required here.