### PR TITLE
Drop gettext initializer

### DIFF
--- a/config/initializers/gettext.rb
+++ b/config/initializers/gettext.rb
@@ -1,5 +1,0 @@
-Vmdb::Gettext::Domains.add_domain(
-  'ManageIQ_Providers_Nsxt',
-  ManageIQ::Providers::Nsxt::Engine.root.join('locale').to_s,
-  :po
-)


### PR DESCRIPTION
The initializer is not needed, since catalogs are part of core now.

@miq-bot add_label cleanup