### PR TITLE
Map CloudTenant To Sub Tenant with the same name

### DIFF
--- a/app/models/manageiq/providers/nsxt/network_manager.rb
+++ b/app/models/manageiq/providers/nsxt/network_manager.rb
@@ -56,4 +56,31 @@ class ManageIQ::Providers::Nsxt::NetworkManager < ManageIQ::Providers::NetworkMa
   def create_security_policy_rule(security_policy_rule)
     ManageIQ::Providers::Nsxt::NetworkManager::SecurityPolicyRule.raw_create_security_policy_rule(self, security_policy_rule)
   end
+
+  def sync_cloud_tenants_with_tenants
+    return unless supports_cloud_tenant_mapping? || !tenant_mapping_enabled
+
+    $nsxt_log.info("Syncing CloudTenants with Tenants for provider #{name}")
+    cloud_tenants.each do |cloud_tenant|
+      next unless cloud_tenant.source_tenant.nil?
+
+      tenant_parent = Tenant.find_by(:name => cloud_tenant.name)
+      next if tenant_parent.nil?
+
+      tenant_name = "Cloud Tenant #{cloud_tenant.name} for Network Provider #{name}"
+      source_tenant = tenant_parent.all_subtenants.find_by(:name => tenant_name) || Tenant.new({:name => tenant_name, :description => tenant_name, :source => cloud_tenant, :parent => tenant_parent})
+      source_tenant.save!
+      cloud_tenant.source_tenant = source_tenant
+      cloud_tenant.save!
+      $nsxt_log.info("New Tenant #{tenant_name} created")
+    end
+  end
+
+  def destroy_mapped_tenants
+    if source_tenant
+      source_tenant.all_subtenants.destroy_all
+      source_tenant.all_subprojects.destroy_all
+      source_tenant.destroy
+    end
+  end
 end

--- a/app/models/manageiq/providers/nsxt/network_manager/refresher.rb
+++ b/app/models/manageiq/providers/nsxt/network_manager/refresher.rb
@@ -5,7 +5,7 @@ module ManageIQ::Providers
     end
 
     def post_process_refresh_classes
-      []
+      [CloudTenant]
     end
   end
 end


### PR DESCRIPTION
Map CloudTenant To Sub Tenant with the same name to support multiple NSX-T provider to connect to the same ManageIQ Tenant.

Link to/Depend on
https://github.com/ManageIQ/manageiq/pull/21135
