### PR TITLE
Use standard persister builder methods from core

### DIFF
--- a/app/models/manageiq/providers/nsxt/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/nsxt/inventory/persister/definitions/network_collections.rb
@@ -2,20 +2,19 @@ module ManageIQ::Providers::Nsxt::Inventory::Persister::Definitions::NetworkColl
   extend ActiveSupport::Concern
   def initialize_network_inventory_collections
     $nsxt_log.info('Collecting NSX-T inventory')
-    %i(network_routers
-       cloud_tenants
-       cloud_networks
-       cloud_subnets
-       security_groups
-       security_policies
-       security_policy_rules
-       network_ports
-       network_services
-       network_service_entries).each do |name|
-
-      add_collection(network, name) do |builder|
-        builder.add_properties(:parent => manager) # including targeted
-      end
+    %i[
+      network_routers
+      cloud_tenants
+      cloud_networks
+      cloud_subnets
+      security_groups
+      security_policies
+      security_policy_rules
+      network_ports
+      network_services
+      network_service_entries
+    ].each do |name|
+      add_network_collection(name)
     end
 
     add_cross_provider_vms


### PR DESCRIPTION
The handling of the "parent" manager has been added as a feature of the
core `add_TYPE_collection`