### PR TITLE
Remove unused VM cross-link collection

### DIFF
--- a/app/models/manageiq/providers/nsxt/inventory/persister/definitions/network_collections.rb
+++ b/app/models/manageiq/providers/nsxt/inventory/persister/definitions/network_collections.rb
@@ -16,18 +16,5 @@ module ManageIQ::Providers::Nsxt::Inventory::Persister::Definitions::NetworkColl
     ].each do |name|
       add_network_collection(name)
     end
-
-    add_cross_provider_vms
-  end
-
-  def add_cross_provider_vms
-    add_collection(cloud, :vms, {}, {:without_sti => true}) do |builder|
-      builder.add_properties(
-        :arel           => Vm.all,
-        :strategy       => :local_db_find_references,
-        :association    => nil,
-        :secondary_refs => { :by_uid_ems => %i(uid_ems) }
-      )
-    end
   end
 end


### PR DESCRIPTION
VM cross-linking isn't currently implemented, remove the collection from the persister