### PR TITLE
Make engine zeitwerk friendly

### DIFF
--- a/lib/manageiq-providers-nsxt.rb
+++ b/lib/manageiq-providers-nsxt.rb
@@ -1,2 +1,0 @@
-require "manageiq/providers/nsxt/engine"
-require "manageiq/providers/nsxt/version"

--- a/lib/manageiq/providers/nsxt.rb
+++ b/lib/manageiq/providers/nsxt.rb
@@ -1,1 +1,2 @@
 require "manageiq/providers/nsxt/engine"
+require "manageiq/providers/nsxt/version"

--- a/lib/manageiq/providers/nsxt/engine.rb
+++ b/lib/manageiq/providers/nsxt/engine.rb
@@ -5,6 +5,7 @@ module ManageIQ
         isolate_namespace ManageIQ::Providers::Nsxt
 
         config.autoload_paths << root.join('lib').to_s
+        config.autoload_paths << root.join('app/helpers/helper').to_s
 
         initializer :append_secrets do |app|
           app.config.paths["config/secrets"] << root.join("config", "secrets.defaults.yml").to_s

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ end
 Dir[Rails.root.join("spec/shared/**/*.rb")].each { |f| require f }
 Dir[File.join(__dir__, "support/**/*.rb")].each { |f| require f }
 
-require "manageiq-providers-nsxt"
+require "manageiq/providers/nsxt"
 
 VCR.configure do |config|
   config.ignore_hosts 'codeclimate.com' if ENV['CI']


### PR DESCRIPTION
* Zeitwerk, the new rails autoloader, doesn't know about this helper directory and
expects the files below it to be in the Helper namespace unless we tell it to
autoload only below this helper directory.

* Use `lib/manageiq/providers/nsxt.rb` as entrypoint instead of `lib/manageiq-providers-nsxt.rb` to follow conventions and be more friendly to zeitwerk.  See second commit.