### PR TITLE
Drop require_nested

### DIFF
--- a/app/models/manageiq/providers/nsxt/inventory.rb
+++ b/app/models/manageiq/providers/nsxt/inventory.rb
@@ -1,9 +1,5 @@
 class ManageIQ::Providers::Nsxt::Inventory < ManageIQ::Providers::Inventory
-  require_nested :Collector
-  require_nested :Parser
-  require_nested :Persister
-
-    # Default manager for building collector/parser/persister classes
+  # Default manager for building collector/parser/persister classes
   # when failed to get class name from refresh target automatically
   def self.default_manager_name
     "NetworkManager"

--- a/app/models/manageiq/providers/nsxt/inventory/collector.rb
+++ b/app/models/manageiq/providers/nsxt/inventory/collector.rb
@@ -1,7 +1,4 @@
 class ManageIQ::Providers::Nsxt::Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-  require_nested :NetworkManager
-  require_nested :TargetCollection
-
   def connection 
     @connection ||= manager.connect
   end

--- a/app/models/manageiq/providers/nsxt/inventory/parser.rb
+++ b/app/models/manageiq/providers/nsxt/inventory/parser.rb
@@ -1,3 +1,2 @@
 class ManageIQ::Providers::Nsxt::Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-  require_nested :NetworkManager
 end

--- a/app/models/manageiq/providers/nsxt/inventory/persister.rb
+++ b/app/models/manageiq/providers/nsxt/inventory/persister.rb
@@ -1,4 +1,2 @@
 class ManageIQ::Providers::Nsxt::Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-  require_nested :NetworkManager
-  require_nested :TargetCollection
 end

--- a/app/models/manageiq/providers/nsxt/network_manager.rb
+++ b/app/models/manageiq/providers/nsxt/network_manager.rb
@@ -1,16 +1,4 @@
 class ManageIQ::Providers::Nsxt::NetworkManager < ManageIQ::Providers::NetworkManager
-  require_nested :CloudNetwork
-  require_nested :CloudSubnet
-  require_nested :NetworkPort
-  require_nested :NetworkRouter
-  require_nested :NetworkService
-  require_nested :NetworkServiceEntry
-  require_nested :RefreshWorker
-  require_nested :Refresher
-  require_nested :SecurityGroup
-  require_nested :SecurityPolicy
-  require_nested :SecurityPolicyRule
-
   supports :cloud_tenant_mapping
   supports :create
   supports :update

--- a/app/models/manageiq/providers/nsxt/network_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/nsxt/network_manager/refresh_worker.rb
@@ -1,6 +1,4 @@
 class ManageIQ::Providers::Nsxt::NetworkManager::RefreshWorker < ManageIQ::Providers::BaseManager::RefreshWorker
-  require_nested :Runner
-
   def self.ems_class
     ManageIQ::Providers::Nsxt::NetworkManager
   end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854