### PR TITLE
Revert "Upgrade package to 2.0.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "packageManager": "yarn@4.2.2",
   "resolutions": {
-    "es-abstract": "~1.21.3",
-    "ip": "2.0.1"
+    "es-abstract": "~1.21.3"
   }
 }


### PR DESCRIPTION
Reverts ManageIQ/manageiq-providers-nsxt#104

This was accidentally sent to master, but the fix only was needed on morphy.  See #105.