### PR TITLE
Delete unused blacklisted_event_names setting

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,6 @@
 ---
 :ems:
   :ems_nsxt:
-    :blacklisted_event_names: []
     :event_handling:
       :event_groups:
 :ems_refresh:


### PR DESCRIPTION
The NSX-t provider doesn't have an event catcher and thus doesn't need a blacklisted_event_names setting.

https://github.com/manageiq/manageiq/issues/19707
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
