### PR TITLE
Fix feature mismatch in NSX-T security policy flow

### DIFF
--- a/app/helpers/helper/manageiq/providers/nsxt/toolbar_overrides/security_policy_center.rb
+++ b/app/helpers/helper/manageiq/providers/nsxt/toolbar_overrides/security_policy_center.rb
@@ -29,7 +29,7 @@ module ManageIQ
                     :klass => ApplicationHelper::Button::BelongsToNsxtNetworkManager
                   ),
                   button(
-                    :nsxt_security_policy_delete,
+                    :security_policy_delete,
                     'pficon pficon-delete fa-lg',
                     t = N_('Remove Security Policy (NSX-T)'),
                     t,
@@ -45,7 +45,7 @@ module ManageIQ
                     :klass => ApplicationHelper::Button::BelongsToNsxtNetworkManager
                   ),
                   button(
-                    :nsxt_security_policy_rule_new,
+                    :security_policy_rule_new,
                     'pficon pficon-add-circle-o fa-lg',
                     t = N_('Add Security Policy Rule (NSX-T)'),
                     t,


### PR DESCRIPTION
Tied to https://github.com/ManageIQ/manageiq-ui-classic/pull/9793

`nsxt_security_policy_rule_new` & `nsxt_security_policy_delete` are not available in [miq_product_features](https://github.com/ManageIQ/manageiq/blob/master/db/fixtures/miq_product_features.yml)

### Before:
<img width="2530" height="1870" alt="image" src="https://github.com/user-attachments/assets/b39cc1a5-beb6-42a0-bb86-c787849a801e" />
<img width="2556" height="1920" alt="image" src="https://github.com/user-attachments/assets/ca5467c4-e5f7-48d9-bfe9-b967484ce2c0" />

### After:
<img width="2586" height="1774" alt="image" src="https://github.com/user-attachments/assets/ee33b45a-e9b4-4a85-a4c3-49a0dd22eaf7" />

@miq-bot add-label bug
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
