### PR TITLE
Migration carbon v11

### DIFF
--- a/app/javascript/components/cloud-networks/delete-nsxt-cloud-network-form.jsx
+++ b/app/javascript/components/cloud-networks/delete-nsxt-cloud-network-form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { ModalBody } from 'carbon-components-react';
+import { ModalBody } from '@carbon/react';
 import { CloudNetworkApi } from '../../utils/cloud-network-api';
 
 class DeleteNsxtCloudNetworkForm extends React.Component {

--- a/app/javascript/components/security-groups/delete-nsxt-security-group-form.jsx
+++ b/app/javascript/components/security-groups/delete-nsxt-security-group-form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { ModalBody } from 'carbon-components-react';
+import { ModalBody } from '@carbon/react';
 import { SecurityGroupApi } from '../../utils/security-group-api';
 
 class DeleteNsxtSecurityGroupForm extends React.Component {

--- a/app/javascript/components/security-policies/delete-nsxt-security-policy-form.jsx
+++ b/app/javascript/components/security-policies/delete-nsxt-security-policy-form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { ModalBody } from 'carbon-components-react';
+import { ModalBody } from '@carbon/react';
 import { SecurityPolicyApi } from '../../utils/security-policy-api';
 
 class DeleteNsxtSecurityPolicyForm extends React.Component {

--- a/app/javascript/components/security-policy-rules/delete-nsxt-security-policy-rule-form.jsx
+++ b/app/javascript/components/security-policy-rules/delete-nsxt-security-policy-rule-form.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { ModalBody } from 'carbon-components-react';
+import { ModalBody } from '@carbon/react';
 import { SecurityPolicyRuleApi } from '../../utils/security-policy-rule-api';
 
 class DeleteNsxtSecurityPolicyRuleForm extends React.Component {


### PR DESCRIPTION
Part of the Carbon-11 migration in manageiq-ui(https://github.com/ManageIQ/manageiq-ui-classic/pull/9799)

**DeleteNsxtCloudNetworkForm:**
<img width="3456" height="1552" alt="image" src="https://github.com/user-attachments/assets/d3cd1174-40fa-4ffc-ba5a-fd47418f534c" />

**DeleteNsxtSecurityGroupForm:**
<img width="3456" height="1690" alt="image" src="https://github.com/user-attachments/assets/4656cb03-b0ef-4283-abc4-2e30926636d8" />

**DeleteNsxtSecurityPolicyForm(requires [manageiq-ui-classic#9793](https://github.com/ManageIQ/manageiq-ui-classic/pull/9793) & https://github.com/ManageIQ/manageiq-providers-nsxt/pull/166):** 
<img width="3442" height="1510" alt="image" src="https://github.com/user-attachments/assets/c6ee5b15-e8d4-4cd6-b098-c2fe1fec56bd" />

**DeleteNsxtSecurityPolicyRuleForm(requires [manageiq-ui-classic#9793](https://github.com/ManageIQ/manageiq-ui-classic/pull/9793)):**
<img width="3456" height="1390" alt="image" src="https://github.com/user-attachments/assets/7e0e661c-5779-469e-ac7f-c9d673a80b14" />

@miq-bot add-label wip
@miq-bot add-label enhancement
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
