### PR TITLE
Delete unused `NetworkManager#create_*` methods

### DIFF
--- a/app/models/manageiq/providers/nsxt/network_manager.rb
+++ b/app/models/manageiq/providers/nsxt/network_manager.rb
@@ -25,20 +25,4 @@ class ManageIQ::Providers::Nsxt::NetworkManager < ManageIQ::Providers::NetworkMa
   def cloud_tenants
     ::CloudTenant.where(:ems_id => id)
   end
-
-  def create_cloud_network(cloud_network)
-    ManageIQ::Providers::Nsxt::NetworkManager::CloudNetwork.raw_create_cloud_network(self, cloud_network)
-  end
-
-  def create_security_group(security_group)
-    ManageIQ::Providers::Nsxt::NetworkManager::SecurityGroup.raw_create_security_group(self, security_group)
-  end
-
-  def create_security_policy(security_policy)
-    ManageIQ::Providers::Nsxt::NetworkManager::SecurityPolicy.raw_create_security_policy(self, security_policy)
-  end
-
-  def create_security_policy_rule(security_policy_rule)
-    ManageIQ::Providers::Nsxt::NetworkManager::SecurityPolicyRule.raw_create_security_policy_rule(self, security_policy_rule)
-  end
 end


### PR DESCRIPTION
These called into CRUD methods that were removed prior to the plugin being adopted due to not having the underlying ansible playbooks that execute the operations.

The methods that these called were deleted in 8050001204922150688c4a38db72a127577514fb which was before the repo was transferred to the `ManageIQ/` org

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
