### PR TITLE
Delete precss and postcss-smart-import

### DIFF
--- a/.postcssrc.yml
+++ b/.postcssrc.yml
@@ -1,4 +1,2 @@
 plugins:
-  postcss-smart-import: {}
-  precss: {}
   autoprefixer: {}


### PR DESCRIPTION
Delete precss and postcss-smart-import as they are not needed after this pr: https://github.com/ManageIQ/manageiq-ui-classic/pull/9960