### PR TITLE
Treat yarn release as a binary to avoid large diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.yarn/releases/yarn-*.cjs binary


### PR DESCRIPTION
Similar change to ManageIQ/manageiq-ui-classic#10043